### PR TITLE
Updated Whitepaper to reflect changes in reward structure, specifying…

### DIFF
--- a/.openzeppelin/base.json
+++ b/.openzeppelin/base.json
@@ -18172,6 +18172,7 @@
       },
       "allAddresses": [
         "0x7764bB31F919d2eBD15CcEeF162b8342A9a7f977",
+        "0x7D86415Ba9E9FE967ad924deC749943fdCE98237",
         "0x22Fc1A1ad685e0c98e88892fD3F0f63e667a65Ef",
         "0x19d0F46Bf9F19f15DDAdCD411498813D2368D881"
       ]
@@ -19433,6 +19434,507 @@
             "numberOfBytes": "20"
           },
           "t_contract(MovinToken)5689": {
+            "label": "contract MovinToken",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_array(t_address)dyn_storage)": {
+            "label": "mapping(address => address[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_array(t_struct(ActivityRecord)2939_storage)dyn_storage)": {
+            "label": "mapping(address => struct MOVINEarnV2.ActivityRecord[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_array(t_struct(Stake)2908_storage)dyn_storage)": {
+            "label": "mapping(address => struct MOVINEarnV2.Stake[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(PremiumUserData)2953_storage)": {
+            "label": "mapping(address => struct MOVINEarnV2.PremiumUserData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(ReferralInfo)2946_storage)": {
+            "label": "mapping(address => struct MOVINEarnV2.ReferralInfo)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(UserActivity)2934_storage)": {
+            "label": "mapping(address => struct MOVINEarnV2.UserActivity)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(ActivityRecord)2939_storage": {
+            "label": "struct MOVINEarnV2.ActivityRecord",
+            "members": [
+              {
+                "label": "value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "timestamp",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(PremiumUserData)2953_storage": {
+            "label": "struct MOVINEarnV2.PremiumUserData",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "paid",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "expiration",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(ReferralInfo)2946_storage": {
+            "label": "struct MOVINEarnV2.ReferralInfo",
+            "members": [
+              {
+                "label": "referrer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "earnedBonus",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "referralCount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(Stake)2908_storage": {
+            "label": "struct MOVINEarnV2.Stake",
+            "members": [
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "startTime",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "lockDuration",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "lastClaimed",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(UserActivity)2934_storage": {
+            "label": "struct MOVINEarnV2.UserActivity",
+            "members": [
+              {
+                "label": "dailySteps",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "dailyMets",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "pendingStepsRewards",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "pendingMetsRewards",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "lastRewardAccumulationTime",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "isPremium",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "lastUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              }
+            ],
+            "numberOfBytes": "224"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:43",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable2Step": [
+            {
+              "contract": "Ownable2StepUpgradeable",
+              "label": "_pendingOwner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol:29",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "b00c3d977c8cc5f471620a1a4293559facd99feb625a2e58eaa28a7307e71d00": {
+      "address": "0x15bf3d4aeA7aCdD36656228E295c0771337314C1",
+      "txHash": "0xa5069e3c54befde9f14b401bc0ab1791bef31a4ea2be7e26b9b6d9423578288d",
+      "layout": {
+        "solcVersion": "0.8.29",
+        "storage": [
+          {
+            "label": "movinToken",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(MovinToken)5695",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:33"
+          },
+          {
+            "label": "erc20MovinToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(ERC20Upgradeable)1384",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:34"
+          },
+          {
+            "label": "lockPeriodMultipliers",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:118"
+          },
+          {
+            "label": "userStakes",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_address,t_array(t_struct(Stake)2908_storage)dyn_storage)",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:119"
+          },
+          {
+            "label": "userActivities",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(UserActivity)2934_storage)",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:120"
+          },
+          {
+            "label": "userStepsHistory",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_array(t_struct(ActivityRecord)2939_storage)dyn_storage)",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:121"
+          },
+          {
+            "label": "userMetsHistory",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_array(t_struct(ActivityRecord)2939_storage)dyn_storage)",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:122"
+          },
+          {
+            "label": "userSteps",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:123"
+          },
+          {
+            "label": "userMets",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:124"
+          },
+          {
+            "label": "userPremiumData",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_address,t_struct(PremiumUserData)2953_storage)",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:125"
+          },
+          {
+            "label": "rewardHalvingTimestamp",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_uint256",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:127"
+          },
+          {
+            "label": "baseStepsRate",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_uint256",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:128"
+          },
+          {
+            "label": "baseMetsRate",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_uint256",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:129"
+          },
+          {
+            "label": "migrator",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_address",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:144"
+          },
+          {
+            "label": "userReferrals",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_mapping(t_address,t_struct(ReferralInfo)2946_storage)",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:146"
+          },
+          {
+            "label": "referrals",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_mapping(t_address,t_array(t_address)dyn_storage)",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:147"
+          },
+          {
+            "label": "transactionSync",
+            "offset": 0,
+            "slot": "16",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:149"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "17",
+            "type": "t_array(t_uint256)47_storage",
+            "contract": "MOVINEarnV2",
+            "src": "contracts/MOVINEarnV2.sol:152"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)146_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Ownable2StepStorage)14_storage": {
+            "label": "struct Ownable2StepUpgradeable.Ownable2StepStorage",
+            "members": [
+              {
+                "label": "_pendingOwner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)74_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)598_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)675_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(ActivityRecord)2939_storage)dyn_storage": {
+            "label": "struct MOVINEarnV2.ActivityRecord[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(Stake)2908_storage)dyn_storage": {
+            "label": "struct MOVINEarnV2.Stake[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]",
+            "numberOfBytes": "1504"
+          },
+          "t_contract(ERC20Upgradeable)1384": {
+            "label": "contract ERC20Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_contract(MovinToken)5695": {
             "label": "contract MovinToken",
             "numberOfBytes": "20"
           },

--- a/Whitepaper.md
+++ b/Whitepaper.md
@@ -66,10 +66,9 @@ Our app includes sophisticated verification mechanisms to ensure rewards are ear
 
 #### Steps Tracking
 
-- Daily steps threshold: 10,000 steps (free users), 5,000 steps (premium users)
 - Maximum daily steps: 30,000 steps (no rewards above)
 - Rate limit: 300 steps per minute
-- Rewards: 1 MVN per threshold reached (0.1% decrease per day)
+- Rewards: 1 MVN per 1000 steps (0.1% decrease per day)
 - Resets at midnight (based on activity timestamp)
 - Any positive steps are rewarded, up to a daily cap of 30,000 steps. Rewards are proportional to the number of steps recorded, up to the daily cap. Per-minute (300 steps/min) and daily caps remain enforced. Rewards rates decrease by 0.1% daily, compounded.
 
@@ -149,9 +148,6 @@ Our app includes sophisticated verification mechanisms to ensure rewards are ear
 
 ### Constants
 
-- STEPS_THRESHOLD: 10,000 (free users)
-- PREMIUM_STEPS_THRESHOLD: 5,000 (premium users)
-- PREMIUM_METS_THRESHOLD: 5 (premium users only)
 - MAX_DAILY_STEPS: 30,000
 - MAX_DAILY_METS: 500
 - MAX_STEPS_PER_MINUTE: 300

--- a/contracts/MOVINEarnV2.sol
+++ b/contracts/MOVINEarnV2.sol
@@ -404,10 +404,11 @@ contract MOVINEarnV2 is
     if (todaySteps > MAX_DAILY_STEPS) todaySteps = MAX_DAILY_STEPS;
     if (todayMets > MAX_DAILY_METS) todayMets = MAX_DAILY_METS;
 
-    uint256 stepsReward = (todaySteps - dailySteps) * baseStepsRate;
+    // Calculate rewards: 1 MVN per 1000 steps
+    uint256 stepsReward = ((todaySteps - dailySteps) * baseStepsRate) / 1000;
     uint256 metsReward = 0;
     if (premiumData.status) {
-      metsReward = (todayMets - dailyMets) * baseMetsRate;
+      metsReward = ((todayMets - dailyMets) * baseMetsRate) / 5;
     }
     return (stepsReward, metsReward, todaySteps, todayMets);
   }


### PR DESCRIPTION
… rewards as 1 MVN per 1000 steps for all users. Modified MOVINEarnV2 contract to implement this new reward calculation and adjusted related tests to ensure accurate reward distribution. Added a new address to OpenZeppelin base configuration for enhanced contract management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Steps Tracking documentation to reflect new reward calculation: users now earn 1 MVN per 1,000 steps, and MET rewards for premium users are scaled to 1 MVN per 5 METs. Previous thresholds and distinctions between free and premium users were removed.

* **Bug Fixes**
  * Adjusted reward calculation logic so that users earn 1 MVN per 1,000 steps and premium users earn 1 MVN per 5 METs, improving consistency and granularity of rewards.

* **Tests**
  * Updated and refined tests to align with the new step and MET reward rates, improved timing controls, and enhanced precision in reward validation.

* **Chores**
  * Registered a new contract implementation and updated relevant addresses for improved contract management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->